### PR TITLE
Optimize hot code

### DIFF
--- a/effect/osci_Effect.cpp
+++ b/effect/osci_Effect.cpp
@@ -95,7 +95,7 @@ void Effect::animateValues(float volume) {
                     newValue = parameter->getValueUnnormalised();
                 }
 				// Just snap if you're close enough smh my head
-				if (actualValues[i] - newValue < EFFECT_SNAP_THRESHOLD) {
+				if (std::abs(actualValues[i] - newValue) < EFFECT_SNAP_THRESHOLD) {
 					actualValues[i] = newValue;
 				} else if (parameter->smoothValueChange.load() >= 1.0f) {
                     actualValues[i] = newValue;

--- a/effect/osci_Effect.cpp
+++ b/effect/osci_Effect.cpp
@@ -99,7 +99,7 @@ void Effect::animateValues(float volume) {
 				} else if (parameter->smoothValueChange.load() >= 1.0f) {
                     actualValues[i] = newValue;
                 } else {
-					float weight = juce::jlimit(SMOOTHING_SPEED_MIN, 1.0f, parameter->smoothValueChange.load()) * 192 / sampleRate;
+					float weight = juce::jlimit(SMOOTHING_SPEED_MIN, 1.0, parameter->smoothValueChange.load()) * 192 / sampleRate;
                     actualValues[i] = (1.0f - weight) * actualValues[i] + weight * newValue;
                 }
 				break;

--- a/effect/osci_Effect.cpp
+++ b/effect/osci_Effect.cpp
@@ -44,7 +44,8 @@ Point Effect::apply(int index, Point input, double volume, bool animate) {
 }
 
 void Effect::animateValues(float volume) {
-	for (int i = 0; i < parameters.size(); i++) {
+	int target = parameters.size();
+	for (int i = 0; i < target; i++) {
 		auto parameter = parameters[i];
 		float minValue = parameter->min;
 		float maxValue = parameter->max;

--- a/effect/osci_Effect.cpp
+++ b/effect/osci_Effect.cpp
@@ -1,5 +1,6 @@
 #include "osci_Effect.h"
 #include <numbers>
+#include <cmath>
 
 namespace osci {
 

--- a/effect/osci_Effect.h
+++ b/effect/osci_Effect.h
@@ -4,6 +4,8 @@
 #include "osci_EffectApplication.h"
 #include "osci_EffectParameter.h"
 
+#define EFFECT_SNAP_THRESHOLD 1e-3
+
 namespace osci {
 
 typedef std::function<Point(int index, Point input, const std::vector<std::atomic<double>>& values, double sampleRate)> EffectApplicationType;
@@ -59,7 +61,7 @@ private:
 	
 	std::shared_ptr<EffectApplication> effectApplication;
 
-	void animateValues(double volume);
+	void animateValues(float volume);
 	float nextPhase(EffectParameter* parameter);
 };
 


### PR DESCRIPTION
This code gets hit A LOT according to the profiling I've been doing, so I have made some optimizations that should speed it up considerably. Primarily, I made everything use floats instead of doubles, and rearranged some math to only be done if needed.