### PR TITLE
Extract cleared effects into core module

### DIFF
--- a/concurrency/readerwritercircularbuffer.h
+++ b/concurrency/readerwritercircularbuffer.h
@@ -19,7 +19,7 @@
 // Note that this implementation is fully modern C++11 (not compatible with old MSVC versions)
 // but we still include atomicops.h for its LightweightSemaphore implementation.
 #ifdef MOODYCAMEL_ATOMICOPS
-#if !OSCI_PROPRIETARY_BUILD && JUCE_MODULE_AVAILABLE_chowdsp_dsp_data_structures
+#if __has_include(<chowdsp_dsp_data_structures/third_party/moodycamel/atomicops.h>)
 #include <chowdsp_dsp_data_structures/third_party/moodycamel/atomicops.h>
 #else
 #include "atomicops.h"

--- a/effects/osci_BitCrushEffect.h
+++ b/effects/osci_BitCrushEffect.h
@@ -23,8 +23,8 @@ public:
 		osci::Point output(dequant * std::round(input.x * quant),
                            dequant * std::round(input.y * quant),
                            dequant * std::round(input.z * quant));
-        return (1 - effectScale) * input + effectScale * output;
-	}
+	        return ((1 - effectScale) * input + effectScale * output).withColour(input.r, input.g, input.b);
+		}
 
 	std::shared_ptr<osci::Effect> build() const override {
         auto eff = std::make_shared<osci::SimpleEffect>(

--- a/effects/osci_BitCrushEffect.h
+++ b/effects/osci_BitCrushEffect.h
@@ -1,0 +1,42 @@
+#pragma once
+#include "../effect/osci_SimpleEffect.h"
+
+#include <cmath>
+
+class BitCrushEffect : public osci::EffectApplication {
+public:
+	std::shared_ptr<osci::EffectApplication> clone() const override {
+		return std::make_shared<BitCrushEffect>();
+	}
+
+	// algorithm from https://www.kvraudio.com/forum/viewtopic.php?t=163880
+	osci::Point apply(int index, osci::Point input, osci::Point externalInput, const std::vector<std::atomic<float>>& values, float sampleRate, float frequency) override {
+		double effectScale = juce::jlimit(0.0f, 1.0f, values[0].load());
+        double value = values[1].load();
+		// change rage of value from 0-1 to 0.0-0.78
+		double rangedValue = value * 0.78;
+		double powValue = pow(2.0f, 1.0 - rangedValue) - 1.0;
+		double crush = powValue * 12;
+		double x = powf(2.0f, crush);
+		double quant = 0.5 * x;
+		double dequant = 1.0f / quant;
+		osci::Point output(dequant * std::round(input.x * quant),
+                           dequant * std::round(input.y * quant),
+                           dequant * std::round(input.z * quant));
+        return (1 - effectScale) * input + effectScale * output;
+	}
+
+	std::shared_ptr<osci::Effect> build() const override {
+        auto eff = std::make_shared<osci::SimpleEffect>(
+            std::make_shared<BitCrushEffect>(),
+            std::vector<osci::EffectParameter*>{
+                new osci::EffectParameter("Bit Crush",
+                                          "Limits the resolution of points drawn to the screen, making the object look pixelated, and making the audio sound more 'digital' and distorted.",
+                                          "bitCrushDryWet", VERSION_HINT, 1.0, 0.0, 1.0),
+                new osci::EffectParameter("Bit Crush Strength",
+                                          "Constrains the resolution which points are limited to.",
+                                          "bitCrush",VERSION_HINT, 0.7, 0.0, 1.0)
+        });
+		return configureBuiltEffect(eff);
+	}
+};

--- a/effects/osci_BulgeEffect.h
+++ b/effects/osci_BulgeEffect.h
@@ -1,0 +1,29 @@
+#pragma once
+#include "../effect/osci_SimpleEffect.h"
+
+#include <cmath>
+
+class BulgeEffect : public osci::EffectApplication {
+public:
+	std::shared_ptr<osci::EffectApplication> clone() const override {
+		return std::make_shared<BulgeEffect>();
+	}
+
+	osci::Point apply(int index, osci::Point input, osci::Point externalInput, const std::vector<std::atomic<float>>& values, float sampleRate, float frequency) override {
+		double value = values[0];
+		double translatedBulge = -value + 1;
+
+		double r = std::hypot(input.x, input.y);
+        if (r == 0) return input;
+		double rn = std::pow(r, translatedBulge);
+		double scale = rn / r;
+		return osci::Point(scale * input.x, scale * input.y, input.z);
+	}
+
+	std::shared_ptr<osci::Effect> build() const override {
+		auto eff = std::make_shared<osci::SimpleEffect>(
+			std::make_shared<BulgeEffect>(),
+			new osci::EffectParameter("Bulge", "Applies a bulge that makes the centre of the image larger, and squishes the edges of the image. This applies a distortion to the audio.", "bulge", VERSION_HINT, 0.5, 0.0, 1.0));
+		return configureBuiltEffect(eff);
+	}
+};

--- a/effects/osci_BulgeEffect.h
+++ b/effects/osci_BulgeEffect.h
@@ -17,8 +17,8 @@ public:
         if (r == 0) return input;
 		double rn = std::pow(r, translatedBulge);
 		double scale = rn / r;
-		return osci::Point(scale * input.x, scale * input.y, input.z);
-	}
+			return osci::Point(scale * input.x, scale * input.y, input.z).withColour(input.r, input.g, input.b);
+		}
 
 	std::shared_ptr<osci::Effect> build() const override {
 		auto eff = std::make_shared<osci::SimpleEffect>(

--- a/effects/osci_DashedLineEffect.h
+++ b/effects/osci_DashedLineEffect.h
@@ -1,0 +1,119 @@
+#pragma once
+#include "../effect/osci_SimpleEffect.h"
+
+#include <cmath>
+
+class DashedLineEffect : public osci::EffectApplication {
+public:
+	std::shared_ptr<osci::EffectApplication> clone() const override {
+		return std::make_shared<DashedLineEffect>();
+	}
+
+	void prepareToPlay(float sampleRate) override {
+		buffer.resize((int)std::ceil(sampleRate));
+		bufferIndex = 0;
+		samplesSinceFrameStart = 0;
+	}
+
+	void onFrameStart() override {
+		bufferIndex = 0;
+		samplesSinceFrameStart = 0;
+	}
+
+	osci::Point apply(int index, osci::Point input, osci::Point externalInput, const std::vector<std::atomic<float>>& values, float sampleRate, float frequency) override {
+		if (buffer.empty()) return input;
+
+		// if only 2 parameters are provided, this is being used as a 'trace effect'
+		// where the dash count is 1.
+		double dashCount = 1.0;
+		int i = 0;
+
+		if (values.size() > 2) {
+			dashCount = juce::jmax(1.0f, values[i++].load()); // Dashes per cycle
+		}
+
+		double dashOffset = values[i++].load();
+		double dashCoverage = juce::jlimit(0.0f, 1.0f, values[i++].load());
+
+		const double safeFrequency = juce::jmax(1.0, (double)frequency);
+		const int cycleSamples = juce::jlimit(1, (int)buffer.size(), (int)std::ceil(sampleRate / safeFrequency));
+
+		// Fallback for contexts where we don't get explicit frame sync pulses
+		if (samplesSinceFrameStart >= cycleSamples) {
+			samplesSinceFrameStart = 0;
+			bufferIndex = 0;
+		}
+
+		const double framePhase01 = (double)samplesSinceFrameStart / (double)cycleSamples; // [0, 1)
+		const double dashLengthSamples = ((double)cycleSamples / dashCount);
+		double dashPhase = framePhase01 * dashCount - dashOffset;
+		dashPhase = dashPhase - std::floor(dashPhase); // Wrap
+
+		buffer[bufferIndex] = input;
+
+		// Linear interpolation works much better than nearest for this
+		double samplePos = bufferIndex - dashLengthSamples * dashPhase * (1.0 - dashCoverage);
+		samplePos = samplePos - cycleSamples * std::floor(samplePos / (double)cycleSamples); // Wrap to [0, cycleSamples)
+		int lowIndex = (int)std::floor(samplePos) % cycleSamples;
+		int highIndex = (lowIndex + 1) % cycleSamples;
+		double mixFactor = samplePos - std::floor(samplePos); // Fractional part
+		osci::Point output = (1 - mixFactor) * buffer[lowIndex] + mixFactor * buffer[highIndex];
+
+		bufferIndex++;
+		if (bufferIndex >= cycleSamples) {
+			bufferIndex = 0;
+		}
+		samplesSinceFrameStart++;
+
+		return output;
+	}
+
+	std::shared_ptr<osci::Effect> build() const override {
+		auto eff = std::make_shared<osci::SimpleEffect>(
+			std::make_shared<DashedLineEffect>(),
+			std::vector<osci::EffectParameter*>{
+				new osci::EffectParameter("Dash Count", "Controls the number of dashed lines in the drawing.", "dashCount", VERSION_HINT, 16.0, 1.0, 32.0),
+				new osci::EffectParameter("Dash Offset", "Offsets the location of the dashed lines.", "dashOffset", VERSION_HINT, 0.0, 0.0, 1.0, 0.0001f, osci::LfoType::Sawtooth, 1.0f),
+				new osci::EffectParameter("Dash Width", "Controls how much each dash unit is drawn.", "dashWidth", VERSION_HINT, 0.5, 0.0, 1.0),
+			}
+		);
+		eff->setName("Dash");
+		return configureBuiltEffect(eff);
+	}
+
+private:
+	std::vector<osci::Point> buffer;
+	int bufferIndex = 0;
+	int samplesSinceFrameStart = 0;
+};
+
+class TraceEffect : public DashedLineEffect {
+public:
+	TraceEffect() : DashedLineEffect() {}
+
+	std::shared_ptr<osci::EffectApplication> clone() const override {
+		return std::make_shared<TraceEffect>();
+	}
+
+	std::shared_ptr<osci::Effect> build() const override {
+		auto eff = std::make_shared<osci::SimpleEffect>(
+			std::make_shared<TraceEffect>(),
+			std::vector<osci::EffectParameter*>{
+				new osci::EffectParameter(
+					"Trace Start",
+					"Defines how far into the frame the drawing is started at. This has the effect of 'tracing' out the image from a single dot when animated. By default, we start drawing from the beginning of the frame, so this value is 0.0.",
+					"traceStart",
+					VERSION_HINT, 0.0, 0.0, 1.0, 0.001
+				),
+				new osci::EffectParameter(
+					"Trace Length",
+					"Defines how much of the frame is drawn per cycle. This has the effect of 'tracing' out the image from a single dot when animated. By default, we draw the whole frame, corresponding to a value of 1.0.",
+					"traceLength",
+					VERSION_HINT, 1.0, 0.0, 1.0, 0.001, osci::LfoType::Sawtooth
+				)
+			}
+		);
+		eff->setName("Trace");
+		return configureBuiltEffect(eff);
+	}
+};

--- a/effects/osci_DuplicatorEffect.h
+++ b/effects/osci_DuplicatorEffect.h
@@ -1,0 +1,50 @@
+#pragma once
+#include "../effect/osci_SimpleEffect.h"
+
+#include <cmath>
+
+class DuplicatorEffect : public osci::EffectApplication {
+public:
+    std::shared_ptr<osci::EffectApplication> clone() const override {
+        return std::make_shared<DuplicatorEffect>();
+    }
+
+    osci::Point apply(int index, osci::Point input, osci::Point externalInput, const std::vector<std::atomic<float>>& values, float sampleRate, float frequency) override {
+        const double twoPi = juce::MathConstants<double>::twoPi;
+        double copies = juce::jmax(1.0f, values[0].load());
+        double spread = juce::jlimit(0.0f, 1.0f, values[1].load());
+        double angleOffset = values[2].load() * juce::MathConstants<double>::twoPi;
+
+        // Offset moves each time the input shape is drawn once
+        double theta = std::floor(framePhase * copies) / copies * twoPi + angleOffset;
+        osci::Point offset(std::cos(theta), std::sin(theta), 0.0);
+
+        double freqDivisor = std::ceil(copies - 1e-3);
+        framePhase += frequency / freqDivisor / sampleRate;
+        framePhase = framePhase - std::floor(framePhase);
+
+        return (1 - spread) * input + spread * offset;
+    }
+
+    std::shared_ptr<osci::Effect> build() const override {
+        auto eff = std::make_shared<osci::SimpleEffect>(
+            std::make_shared<DuplicatorEffect>(),
+            std::vector<osci::EffectParameter*>{
+                new osci::EffectParameter("Duplicator Copies",
+                                          "Controls the number of copies of the input shape to draw. Splitting the shape into multiple copies creates audible harmony.",
+                                          "duplicatorCopies", VERSION_HINT, 3.0, 1.0, 6.0),
+                new osci::EffectParameter("Spread",
+                                          "Controls the spread between copies of the input shape.",
+                                          "duplicatorSpread", VERSION_HINT, 0.4, 0.0, 1.0),
+                new osci::EffectParameter("Angle Offset",
+                                          "Rotates the offsets between copies without rotating the input shape.",
+                                          "duplicatorAngle", VERSION_HINT, 0.0, 0.0, 1.0, 0.0001, osci::LfoType::Sawtooth, 0.1)
+            }
+        );
+        eff->setName("Duplicator");
+        return configureBuiltEffect(eff);
+    }
+
+private:
+    double framePhase = 0.0; // [0, 1]
+};

--- a/effects/osci_DuplicatorEffect.h
+++ b/effects/osci_DuplicatorEffect.h
@@ -23,7 +23,7 @@ public:
         framePhase += frequency / freqDivisor / sampleRate;
         framePhase = framePhase - std::floor(framePhase);
 
-        return (1 - spread) * input + spread * offset;
+        return ((1 - spread) * input + spread * offset).withColour(input.r, input.g, input.b);
     }
 
     std::shared_ptr<osci::Effect> build() const override {

--- a/effects/osci_GodRayEffect.h
+++ b/effects/osci_GodRayEffect.h
@@ -1,8 +1,8 @@
 #pragma once
 #include "../effect/osci_SimpleEffect.h"
 
+#include <cstdint>
 #include <cmath>
-#include <cstdlib>
 
 class GodRayEffect : public osci::EffectApplication {
 public:
@@ -15,7 +15,7 @@ public:
         double bias = values[1];
         double biasExponent = std::pow(12.0, std::abs(bias));
 
-        double noise = (double)std::rand() / RAND_MAX;
+        double noise = nextNoise();
         // Bias values toward 0 or 1 based on sign
         if (bias > 0.0) {
             noise = std::pow(noise, biasExponent);
@@ -40,4 +40,14 @@ public:
         eff->setName("God Ray");
         return configureBuiltEffect(eff);
     }
+
+private:
+    double nextNoise() noexcept {
+        rngState ^= rngState << 13;
+        rngState ^= rngState >> 17;
+        rngState ^= rngState << 5;
+        return static_cast<double>(rngState & 0x00ffffffu) / static_cast<double>(0x01000000u);
+    }
+
+    std::uint32_t rngState = 0x9e3779b9u;
 };

--- a/effects/osci_GodRayEffect.h
+++ b/effects/osci_GodRayEffect.h
@@ -1,0 +1,43 @@
+#pragma once
+#include "../effect/osci_SimpleEffect.h"
+
+#include <cmath>
+#include <cstdlib>
+
+class GodRayEffect : public osci::EffectApplication {
+public:
+    std::shared_ptr<osci::EffectApplication> clone() const override {
+        return std::make_shared<GodRayEffect>();
+    }
+
+    osci::Point apply(int index, osci::Point input, osci::Point externalInput, const std::vector<std::atomic<float>>&values, float sampleRate, float frequency) override {
+        double noiseAmp = juce::jmax(0.0f, values[0].load());
+        double bias = values[1];
+        double biasExponent = std::pow(12.0, std::abs(bias));
+
+        double noise = (double)std::rand() / RAND_MAX;
+        // Bias values toward 0 or 1 based on sign
+        if (bias > 0.0) {
+            noise = std::pow(noise, biasExponent);
+        } else {
+            noise = 1 - std::pow(1 - noise, biasExponent);
+        }
+        double scale = (1 - noiseAmp) + noise * noiseAmp;
+        return input * scale;
+    }
+
+    std::shared_ptr<osci::Effect> build() const override {
+        auto eff = std::make_shared<osci::SimpleEffect>(
+            std::make_shared<GodRayEffect>(),
+            std::vector<osci::EffectParameter*>{
+                new osci::EffectParameter("God Ray Strength",
+                                          "Creates a god ray effect by adding noise. This slider controls the size of the rays. Looks best with higher sample rates.",
+                                          "godRayStrength", VERSION_HINT, 0.5, 0.0, 1.0),
+                new osci::EffectParameter("God Ray Position",
+                                          "Controls whether the rays appear to be radiating inward or outward.",
+                                          "godRayPosition", VERSION_HINT, 0.8, -1.0, 1.0)
+        });
+        eff->setName("God Ray");
+        return configureBuiltEffect(eff);
+    }
+};

--- a/effects/osci_KaleidoscopeEffect.h
+++ b/effects/osci_KaleidoscopeEffect.h
@@ -1,0 +1,106 @@
+#pragma once
+#include "../effect/osci_SimpleEffect.h"
+
+#include <algorithm>
+#include <cmath>
+
+class KaleidoscopeEffect : public osci::EffectApplication {
+public:
+    std::shared_ptr<osci::EffectApplication> clone() const override {
+        return std::make_shared<KaleidoscopeEffect>();
+    }
+
+    osci::Point apply(int index, osci::Point input, osci::Point externalInput, const std::vector<std::atomic<float>>& values, float sampleRate, float frequency) override {
+        const double pi = juce::MathConstants<double>::pi;
+        const double twoPi = juce::MathConstants<double>::twoPi;
+        double segments = juce::jmax(1.0f, values[0].load());
+        double mirror = values[1].load();
+        double spread = juce::jlimit(0.0f, 1.0f, values[2].load());
+        double clip = juce::jlimit(0.0f, 1.0f, values[3].load());
+
+        // To start, treat everything as if we are on the +X (theta = 0) segment
+        // Rotate input shape 90 deg CW so the shape is always "upright" 
+        // relative to the radius
+        // Then apply spread
+        input = osci::Point(input.y, -input.x, input.z);
+        osci::Point output = (1 - spread) * input;
+        output.x += spread;
+
+        // Mirror the y of every other segment if enabled
+        double currentSegment = std::floor(framePhase * segments);
+        if ((int)currentSegment % 2 == 1) {
+            output.y *= (1 - 2 * mirror);
+        }
+
+        // Clip the shape to remain within this radial segment
+        double segmentSize = twoPi / segments; // Angular size
+        osci::Point upperPlaneNormal(std::sin(0.5 * segmentSize), -std::cos(0.5 * segmentSize), 0);
+        osci::Point lowerPlaneNormal(upperPlaneNormal.x, -upperPlaneNormal.y, 0);
+        osci::Point clippedOutput;
+        if (segmentSize < pi) {
+            clippedOutput = clipToPlane(output, upperPlaneNormal);
+            clippedOutput = clipToPlane(clippedOutput, lowerPlaneNormal);
+            // Point could still lie left of the origin along the lower plane
+            if (clippedOutput.x < 0) {
+                clippedOutput.x = 0;
+                clippedOutput.y = 0;
+            }
+        } else {
+            // segmentSize is wider than 180 degrees
+            // If the point is clipped to both planes like above, the actual result region
+            // will be less than 180 degrees
+            // So only clip to one plane at a time
+            if (output.y > 0) {
+                clippedOutput = clipToPlane(output, upperPlaneNormal);
+            } else {
+                clippedOutput = clipToPlane(output, lowerPlaneNormal);
+            }
+        }
+        output = (1 - clip) * output + clip * clippedOutput;
+
+        // Finally, rotate this radial segment to its actual location
+        double rotTheta = (currentSegment / segments) * twoPi;
+        output.rotate(0, 0, rotTheta);
+
+        double freqDivisor = std::ceil(segments - 1e-3);
+        framePhase += frequency / freqDivisor / sampleRate;
+        framePhase = framePhase - std::floor(framePhase);
+
+        return output;
+    }
+
+    std::shared_ptr<osci::Effect> build() const override {
+        auto eff = std::make_shared<osci::SimpleEffect>(
+            std::make_shared<KaleidoscopeEffect>(),
+            std::vector<osci::EffectParameter*>{
+                new osci::EffectParameter("Kaeidoscope Segments",
+                                          "Controls how many times the input shape is rotationally duplicated around the centre.",
+                                          "kaleidoscopeSegments", VERSION_HINT, 6.0, 1.0, 6.0, 0.0001, osci::LfoType::Sine, 0.2), 
+                new osci::EffectParameter("Mirror",
+                                          "Mirrors every other segment like a real kaleidoscope. Best used in combination with an even number of segments.",
+                                          "kaleidoscopeMirror", VERSION_HINT, 1.0, 0.0, 1.0),
+                new osci::EffectParameter("Spread",
+                                          "Controls the radial spread of each segment.",
+                                          "kaleidoscopeSpread", VERSION_HINT, 0.4, 0.0, 1.0),
+                new osci::EffectParameter("Clip",
+                                          "Clips each copy of the input shape within its own segment.",
+                                          "kaleidoscopeClip", VERSION_HINT, 1.0, 0.0, 1.0)
+            }
+        );
+        eff->setName("Kaleidoscope");
+        return configureBuiltEffect(eff);
+    }
+
+private:
+    double framePhase = 0.0; // [0, 1]
+
+    // Clips points behind the plane to the plane
+    // Leaves points in front of the plane untouched
+    osci::Point clipToPlane(osci::Point input, osci::Point planeNormal)
+    {
+        double distToPlane = input.innerProduct(planeNormal);
+        double clippedDist = std::max(0.0, distToPlane);
+        double distAdjustment = clippedDist - distToPlane;
+        return input + distAdjustment * planeNormal;
+    }
+};

--- a/effects/osci_MultiplexEffect.h
+++ b/effects/osci_MultiplexEffect.h
@@ -1,0 +1,115 @@
+#pragma once
+#include "../effect/osci_SimpleEffect.h"
+
+#include <algorithm>
+#include <cmath>
+#include <numbers>
+
+class MultiplexEffect : public osci::EffectApplication {
+public:
+    std::shared_ptr<osci::EffectApplication> clone() const override {
+        return std::make_shared<MultiplexEffect>();
+    }
+
+    void prepareToPlay(float sampleRate) override {
+        buffer.resize((int)sampleRate);
+        head = 0;
+    }
+
+    osci::Point apply(int index, osci::Point input, osci::Point externalInput, const std::vector<std::atomic<float>>& values, float sampleRate, float frequency) override {
+        jassert(values.size() == 5);
+
+        if (buffer.empty()) return input;
+
+        double gridX = values[0].load();
+        double gridY = values[1].load();
+        double gridZ = values[2].load();
+        double interpolation = values[3].load();
+        double gridDelay = values[4].load();
+
+        head++;
+        if (head >= (int)buffer.size()) {
+            head = 0;
+        }
+        buffer[head] = input;
+
+        osci::Point grid = osci::Point(gridX, gridY, gridZ);
+        osci::Point gridFloor = osci::Point(std::floor(gridX + 1e-3),
+                                            std::floor(gridY + 1e-3),
+                                            std::floor(gridZ + 1e-3));
+
+        gridFloor.x = std::max(gridFloor.x, 1.0f);
+        gridFloor.y = std::max(gridFloor.y, 1.0f);
+        gridFloor.z = std::max(gridFloor.z, 1.0f);
+
+        double totalPositions = gridFloor.x * gridFloor.y * gridFloor.z;
+        double position = phase * totalPositions;
+        double delayPosition = static_cast<int>(position) / totalPositions;
+
+        phase = (nextPhase(frequency / totalPositions, sampleRate) + juce::MathConstants<float>::pi) / (2.0 * juce::MathConstants<float>::pi);
+
+        int delayedIndex = head - static_cast<int>(delayPosition * gridDelay * sampleRate);
+        if (delayedIndex < 0) {
+            delayedIndex += buffer.size();
+        }
+        osci::Point delayedInput = buffer[delayedIndex % buffer.size()];
+
+        osci::Point nextGrid = gridFloor + 1.0;
+
+        osci::Point current = multiplex(delayedInput, position, gridFloor);
+        osci::Point next = multiplex(delayedInput, position, nextGrid);
+
+        // Calculate interpolation factors
+        osci::Point gridDiff = grid - gridFloor;
+        osci::Point interpolationFactor = gridDiff * interpolation;
+
+        return (1.0 - interpolationFactor) * current + interpolationFactor * next;
+    }
+
+    std::shared_ptr<osci::Effect> build() const override {
+        auto eff = std::make_shared<osci::SimpleEffect>(
+            std::make_shared<MultiplexEffect>(),
+            std::vector<osci::EffectParameter*>{
+                new osci::EffectParameter("Multiplex X", "Controls the horizontal grid size for the multiplex effect.", "multiplexGridX", VERSION_HINT, 2.0, 1.0, 8.0),
+                new osci::EffectParameter("Multiplex Y", "Controls the vertical grid size for the multiplex effect.", "multiplexGridY", VERSION_HINT, 2.0, 1.0, 8.0),
+                new osci::EffectParameter("Multiplex Z", "Controls the depth grid size for the multiplex effect.", "multiplexGridZ", VERSION_HINT, 1.0, 1.0, 8.0),
+                new osci::EffectParameter("Multiplex Smooth", "Controls the smoothness of transitions between grid sizes.", "multiplexSmooth", VERSION_HINT, 0.0, 0.0, 1.0),
+                new osci::EffectParameter("Multiplex Delay", "Controls the delay of the audio samples used in the multiplex effect.", "gridDelay", VERSION_HINT, 0.0, 0.0, 1.0),
+            }
+        );
+        eff->setName("Multiplex");
+        return configureBuiltEffect(eff);
+    }
+
+private:
+    osci::Point multiplex(osci::Point point, double position, osci::Point grid) {
+        osci::Point unit = 1.0 / grid;
+
+        point *= unit;
+        point.x = -point.x;
+        point.y = -point.y;
+
+        double xPosRaw = std::floor(position);
+        double yPosRaw = std::floor(position / grid.x);
+        double zPosRaw = std::floor(position / (grid.x * grid.y));
+
+        // Use fmod for positive modulo with doubles
+        double xPos = std::fmod(std::fmod(xPosRaw, grid.x) + grid.x, grid.x);
+        double yPos = std::fmod(std::fmod(yPosRaw, grid.y) + grid.y, grid.y);
+        double zPos = std::fmod(std::fmod(zPosRaw, grid.z) + grid.z, grid.z);
+
+        point.x -= (grid.x - 1.0) / grid.x;
+        point.y += (grid.y - 1.0) / grid.y;
+        point.z += (grid.z - 1.0) / grid.z;
+
+        point.x += xPos * 2.0 * unit.x;
+        point.y -= yPos * 2.0 * unit.y;
+        point.z -= zPos * 2.0 * unit.z;
+
+        return point;
+    }
+
+    double phase = 0.0; // Normalised 0..1 phase for multiplex traversal
+    std::vector<osci::Point> buffer;
+    int head = 0;
+};

--- a/effects/osci_PerspectiveEffect.h
+++ b/effects/osci_PerspectiveEffect.h
@@ -1,0 +1,48 @@
+#pragma once
+#include "../effect/osci_SimpleEffect.h"
+#include "../geometry/osci_PerspectiveProjector.h"
+
+#include <cmath>
+
+class PerspectiveEffect : public osci::EffectApplication {
+public:
+	std::shared_ptr<osci::EffectApplication> clone() const override {
+		return std::make_shared<PerspectiveEffect>();
+	}
+
+	osci::Point apply(int index, osci::Point input, osci::Point externalInput, const std::vector<std::atomic<float>>& values, float sampleRate, float frequency) override {
+		auto effectScale = values[0].load();
+		// Far plane clipping happens at about 1.2 deg for 100 far plane dist
+		float fovDegrees = juce::jlimit(1.5f, 179.0f, values[1].load());
+		float fov = juce::degreesToRadians(fovDegrees);
+
+		// Place camera such that field of view is tangent to unit sphere
+		osci::Vec3 origin = osci::Vec3(0, 0, -1.0f / std::sin(0.5f * (float)fov));
+		projector.setCameraPosition(origin);
+		projector.setFieldOfViewRadians(fov);
+		osci::Vec3 vec = osci::Vec3(input.x, input.y, input.z);
+
+		osci::Vec3 projected = projector.project(vec);
+
+		return osci::Point(
+			(1 - effectScale) * input.x + effectScale * projected.x,
+			(1 - effectScale) * input.y + effectScale * projected.y,
+			0
+		);
+	}
+
+	std::shared_ptr<osci::Effect> build() const override {
+		auto eff = std::make_shared<osci::SimpleEffect>(
+			std::make_shared<PerspectiveEffect>(),
+			std::vector<osci::EffectParameter*>{
+				new osci::EffectParameter("Perspective", "Controls the strength of the 3D perspective projection.", "perspectiveStrength", VERSION_HINT, 1.0, 0.0, 1.0),
+				new osci::EffectParameter("Field of View", "Controls the camera's field of view in degrees. A lower field of view makes the image look more flat, and a higher field of view makes the image look more 3D.", "perspectiveFov", VERSION_HINT, 50.0, 5.0, 130.0),
+			}
+		);
+		return configureBuiltEffect(eff);
+	}
+
+private:
+	
+	osci::PerspectiveProjector projector;
+};

--- a/effects/osci_PerspectiveEffect.h
+++ b/effects/osci_PerspectiveEffect.h
@@ -24,12 +24,12 @@ public:
 
 		osci::Vec3 projected = projector.project(vec);
 
-		return osci::Point(
-			(1 - effectScale) * input.x + effectScale * projected.x,
-			(1 - effectScale) * input.y + effectScale * projected.y,
-			0
-		);
-	}
+			return osci::Point(
+				(1 - effectScale) * input.x + effectScale * projected.x,
+				(1 - effectScale) * input.y + effectScale * projected.y,
+				0
+			).withColour(input.r, input.g, input.b);
+		}
 
 	std::shared_ptr<osci::Effect> build() const override {
 		auto eff = std::make_shared<osci::SimpleEffect>(

--- a/effects/osci_PolygonizerEffect.h
+++ b/effects/osci_PolygonizerEffect.h
@@ -41,7 +41,7 @@ public:
             double signZ = input.z > 0 ? 1 : -1;
             output.z = signZ * juce::jmax(0.0, (std::round(absZ / stripeSize - stripePhase) + stripePhase) * stripeSize);
         }
-        return (1 - effectScale) * input + effectScale * output;
+        return ((1 - effectScale) * input + effectScale * output).withColour(input.r, input.g, input.b);
     }
 
     std::shared_ptr<osci::Effect> build() const override {

--- a/effects/osci_PolygonizerEffect.h
+++ b/effects/osci_PolygonizerEffect.h
@@ -1,0 +1,67 @@
+#pragma once
+#include "../effect/osci_SimpleEffect.h"
+#include "../osci_Util.h"
+
+#include <cmath>
+
+// Inspired by xenontesla122
+class PolygonizerEffect : public osci::EffectApplication {
+public:
+    std::shared_ptr<osci::EffectApplication> clone() const override {
+        return std::make_shared<PolygonizerEffect>();
+    }
+
+    osci::Point apply(int index, osci::Point input, osci::Point externalInput, const std::vector<std::atomic<float>>&values, float sampleRate, float frequency) override {
+        const double pi = juce::MathConstants<double>::pi;
+        const double twoPi = juce::MathConstants<double>::twoPi;
+        double effectScale = juce::jlimit(0.0f, 1.0f, values[0].load());
+        double nSides = juce::jmax(2.0f, values[1].load());
+        double stripeSize = juce::jmax(1e-4f, values[2].load());
+        stripeSize = std::pow(0.63 * stripeSize, 1.5); // Change range and bias toward smaller values
+        double rotation = values[3] * twoPi;
+        double stripePhase = values[4];
+
+        osci::Point output(0);
+        if (input.x != 0 || input.y != 0) {
+            // Note 90 degree rotation: Theta is treated relative to +Y rather than +X
+            double r = std::hypot(input.x, input.y);
+            double theta = std::atan2(-input.x, input.y) - rotation;
+            theta = osci::Util::wrapAngle(theta + pi) - pi; // Move branch cut to +/-pi after angle offset is applied
+            double regionCenterTheta = std::round(theta * nSides / twoPi) / nSides * twoPi;
+            double localTheta = theta - regionCenterTheta;
+            double dist = r * std::cos(localTheta);
+            double newDist = juce::jmax(0.0, (std::round(dist / stripeSize - stripePhase) + stripePhase) * stripeSize);
+            double scale = newDist / dist;
+            output.x = scale * input.x;
+            output.y = scale * input.y;
+        }
+        // Apply the same stripe quantization to abs(z) if the input is 3D
+        double absZ = std::abs(input.z);
+        if (absZ > 0.0001) {
+            double signZ = input.z > 0 ? 1 : -1;
+            output.z = signZ * juce::jmax(0.0, (std::round(absZ / stripeSize - stripePhase) + stripePhase) * stripeSize);
+        }
+        return (1 - effectScale) * input + effectScale * output;
+    }
+
+    std::shared_ptr<osci::Effect> build() const override {
+        auto eff = std::make_shared<osci::SimpleEffect>(
+            std::make_shared<PolygonizerEffect>(),
+            std::vector<osci::EffectParameter*>{
+                new osci::EffectParameter("Polygonizer",
+                                          "Constrains points to a polygon pattern.",
+                                          "polygonizer", VERSION_HINT, 1.0, 0.0, 1.0),
+                new osci::EffectParameter("Sides", "Controls the number of sides of the polygon pattern.",
+                                          "polygonizerSides", VERSION_HINT, 5.0, 3.0, 8.0),
+                new osci::EffectParameter("Stripe Size",
+                                          "Controls the spacing between the stripes of the polygon pattern.",
+                                          "polygonizerStripeSize", VERSION_HINT, 0.5, 0.0, 1.0),
+                new osci::EffectParameter("Rotation", "Rotates the polygon pattern.",
+                                          "polygonizerRotation", VERSION_HINT, 0.0, 0.0, 1.0, 0.0001, osci::LfoType::Sawtooth, 0.1),
+                new osci::EffectParameter("Stripe Phase", "Offsets the stripes of the polygon pattern.",
+                                          "polygonizerStripePhase", VERSION_HINT, 0.0, 0.0, 1.0, 0.0001, osci::LfoType::Sawtooth, 2.0)
+            }
+        );
+        return configureBuiltEffect(eff);
+    }
+};

--- a/effects/osci_SpiralBitCrushEffect.h
+++ b/effects/osci_SpiralBitCrushEffect.h
@@ -1,0 +1,83 @@
+#pragma once
+#include "../effect/osci_SimpleEffect.h"
+
+#include <cmath>
+
+class SpiralBitCrushEffect : public osci::EffectApplication {
+public:
+	std::shared_ptr<osci::EffectApplication> clone() const override {
+		return std::make_shared<SpiralBitCrushEffect>();
+	}
+
+	osci::Point apply(int index, osci::Point input, osci::Point externalInput, const std::vector<std::atomic<float>>&values, float sampleRate, float frequency) override {
+		// Completing one revolution in input space traverses the hypotenuse of one "domain" in log-polar space
+        double effectScale = juce::jlimit(0.0f, 1.0f, values[0].load());
+		double domainX = juce::jmax(2.0, std::floor(values[1].load() + 0.001));
+		double domainY = std::round(domainX * values[2].load());
+        double zoom = values[3].load() * juce::MathConstants<double>::twoPi; // Use same scale as angle
+        double rotation = values[4].load() * juce::MathConstants<double>::twoPi;
+        
+		double domainHypot = std::hypot(domainX, domainY);
+		double domainTheta = std::atan2(domainY, domainX);
+		double scale = domainHypot / juce::MathConstants<double>::twoPi;
+		osci::Point output(0);
+
+		// Round to log-polar grid
+		if (input.x != 0 || input.y != 0) {
+			// Convert input point to log-polar coordinates transformed based on domain and offset
+			// Note 90 degree rotation: Theta is treated relative to -Y rather than +X
+			double r = std::hypot(input.x, input.y);
+			double logR = std::log(r);
+			double theta = std::atan2(input.x, -input.y);
+			osci::Point logPolarCoords(theta - rotation, logR - zoom);
+			logPolarCoords.rotate(0, 0, domainTheta);
+			logPolarCoords = logPolarCoords * scale;
+
+			// Round this point to the center of the log-polar cell the input lies in, convert back to Cartesian
+			logPolarCoords.x = std::round(logPolarCoords.x);
+			logPolarCoords.y = std::round(logPolarCoords.y);
+			logPolarCoords = logPolarCoords / scale;
+			logPolarCoords.rotate(0, 0, -domainTheta);
+			double outR = std::exp(logPolarCoords.y + zoom);
+			double outTheta = logPolarCoords.x + rotation;
+			output.x = outR *  std::sin(outTheta);
+			output.y = outR * -std::cos(outTheta);
+		}
+
+		// Round z in log space using same spacing as xy log-polar grid
+		// Use same offset as xy's radial offset to be consistent with the appearance of zooming
+		if (input.z != 0) {
+			double signZ = input.z > 0 ? 1.0 : -1.0;
+			double logZ = std::log(std::abs(input.z));
+			logZ = (logZ - zoom) * scale;
+			logZ = std::round(logZ);
+            logZ = logZ / scale + zoom;
+			output.z = signZ * std::exp(logZ);
+		}
+		return (1 - effectScale) * input + effectScale * output;
+	}
+
+	std::shared_ptr<osci::Effect> build() const override {
+        auto eff = std::make_shared<osci::SimpleEffect>(
+            std::make_shared<SpiralBitCrushEffect>(),
+            std::vector<osci::EffectParameter*>{
+                new osci::EffectParameter("Spiral Bit Crush",
+                                          "Constrains points to a spiral pattern.",
+                                          "spiralBitCrush", VERSION_HINT, 0.4, 0.0, 1.0),
+                new osci::EffectParameter("Spiral Density",
+                                          "Controls the density of the spiral pattern.",
+                                          "spiralBitCrushDensity", VERSION_HINT, 13.0, 3.0, 30.0, 1.0),
+                new osci::EffectParameter("Spiral Twist",
+                                          "Controls how much the spiral pattern twists.",
+                                          "spiralBitCrushTwist", VERSION_HINT, 0.6, -1.0, 1.0),
+                new osci::EffectParameter("Zoom",
+                                          "Zooms the spiral pattern.",
+                                          "spiralBitCrushZoom", VERSION_HINT, 0.0, 0.0, 1.0, 0.0001, osci::LfoType::Sawtooth, 0.1),
+                new osci::EffectParameter("Rotation",
+                                          "Rotates the spiral pattern.",
+                                          "spiralBitCrushRotation", VERSION_HINT, 0.0, 0.0, 1.0, 0.0001, osci::LfoType::ReverseSawtooth, 0.02)
+            }
+        );
+		return configureBuiltEffect(eff);
+	}
+};

--- a/effects/osci_SpiralBitCrushEffect.h
+++ b/effects/osci_SpiralBitCrushEffect.h
@@ -54,8 +54,8 @@ public:
             logZ = logZ / scale + zoom;
 			output.z = signZ * std::exp(logZ);
 		}
-		return (1 - effectScale) * input + effectScale * output;
-	}
+			return ((1 - effectScale) * input + effectScale * output).withColour(input.r, input.g, input.b);
+		}
 
 	std::shared_ptr<osci::Effect> build() const override {
         auto eff = std::make_shared<osci::SimpleEffect>(

--- a/effects/osci_TwistEffect.h
+++ b/effects/osci_TwistEffect.h
@@ -1,0 +1,26 @@
+#pragma once
+#include "../effect/osci_SimpleEffect.h"
+
+#include <numbers>
+
+class TwistEffect : public osci::EffectApplication {
+public:
+	std::shared_ptr<osci::EffectApplication> clone() const override {
+		return std::make_shared<TwistEffect>();
+	}
+
+	osci::Point apply(int index, osci::Point input, osci::Point externalInput, const std::vector<std::atomic<float>>&values, float sampleRate, float frequency) override {
+		double twistStrength = values[0] * 4 * std::numbers::pi;
+		double twistTheta = twistStrength * input.y;
+		input.rotate(0.0, twistTheta, 0.0);
+		return input;
+	}
+    
+    std::shared_ptr<osci::Effect> build() const override {
+        auto eff = std::make_shared<osci::SimpleEffect>(
+            std::make_shared<TwistEffect>(),
+            new osci::EffectParameter("Twist", "Twists the image in a corkscrew pattern.", "twist", VERSION_HINT, 0.5, 0.0, 1.0, 0.0001, osci::LfoType::Sine, 0.5)
+        );
+        return configureBuiltEffect(eff);
+    }
+};

--- a/effects/osci_VortexEffect.h
+++ b/effects/osci_VortexEffect.h
@@ -1,0 +1,49 @@
+#pragma once
+#include "../effect/osci_SimpleEffect.h"
+
+#include <cmath>
+
+class VortexEffect : public osci::EffectApplication {
+public:
+    std::shared_ptr<osci::EffectApplication> clone() const override {
+        return std::make_shared<VortexEffect>();
+    }
+
+    osci::Point apply(int index, osci::Point input, osci::Point externalInput, const std::vector<std::atomic<float>>&values, float sampleRate, float frequency) override {
+        // Treat input as complex number and raise to integer power
+        // Disallowing non-integer and negative exponents because of the branch cut
+        double effectScale = juce::jlimit(0.0f, 1.0f, values[0].load());
+        double exponent = juce::jmax(1.0, std::floor(values[1].load() + 0.001));
+        double refTheta = values[2].load() * juce::MathConstants<double>::twoPi;
+
+        osci::Point output(0, 0, input.z);
+        if (input.x != 0 || input.y != 0) {
+            double r2 = input.x * input.x + input.y * input.y;
+            double theta = std::atan2(input.y, input.x) - refTheta;
+
+            double outR = std::pow(r2, 0.5 * exponent);
+            double outTheta = exponent * theta + refTheta;
+            output.x = outR * std::cos(outTheta);
+            output.y = outR * std::sin(outTheta);
+        }
+        return (1 - effectScale) * input + effectScale * output;
+    }
+
+    std::shared_ptr<osci::Effect> build() const override {
+        auto eff = std::make_shared<osci::SimpleEffect>(
+            std::make_shared<VortexEffect>(),
+            std::vector<osci::EffectParameter *>{
+                new osci::EffectParameter("Vortex Strength",
+                                          "Controls the strength of the vortex effect.",
+                                          "vortexStrength", VERSION_HINT, 0.6, 0.0, 1.0),
+                new osci::EffectParameter("Vortex Amount",
+                                          "The multiplier applied to each point's angle, creating more vortexes.",
+                                          "vortexAmount", VERSION_HINT, 2.0, 2.0, 6.0, 1.0),
+                new osci::EffectParameter("Vortex Rotation",
+                                          "The rotation applied to each point.",
+                                          "vortexRotation", VERSION_HINT, 0.25, 0.0, 1.0, 0.0001, osci::LfoType::Sawtooth, 0.2)
+        });
+        eff->setName("Vortex");
+        return configureBuiltEffect(eff);
+    }
+};

--- a/effects/osci_VortexEffect.h
+++ b/effects/osci_VortexEffect.h
@@ -26,7 +26,7 @@ public:
             output.x = outR * std::cos(outTheta);
             output.y = outR * std::sin(outTheta);
         }
-        return (1 - effectScale) * input + effectScale * output;
+        return ((1 - effectScale) * input + effectScale * output).withColour(input.r, input.g, input.b);
     }
 
     std::shared_ptr<osci::Effect> build() const override {

--- a/effects/osci_WobbleEffect.h
+++ b/effects/osci_WobbleEffect.h
@@ -1,0 +1,30 @@
+#pragma once
+#include "../effect/osci_SimpleEffect.h"
+
+#include <numbers>
+
+class WobbleEffect : public osci::EffectApplication {
+public:
+    std::shared_ptr<osci::EffectApplication> clone() const override {
+        return std::make_shared<WobbleEffect>();
+    }
+
+    osci::Point apply(int index, osci::Point input, osci::Point externalInput, const std::vector<std::atomic<float>>& values, float sampleRate, float frequency) override {
+        double wobblePhase = values[1] * std::numbers::pi;
+        double theta = nextPhase(frequency, sampleRate) + wobblePhase;
+        double delta = 0.5 * values[0] * juce::dsp::FastMathApproximations::sin(theta);
+
+        return input + delta;
+    }
+
+	std::shared_ptr<osci::Effect> build() const override {
+        auto wobble = std::make_shared<osci::SimpleEffect>(
+            std::make_shared<WobbleEffect>(),
+            std::vector<osci::EffectParameter*>{
+                new osci::EffectParameter("Wobble Amount", "Adds a sine wave of the prominent frequency in the audio currently playing. The sine wave's frequency is slightly offset to create a subtle 'wobble' in the image. Increasing the slider increases the strength of the wobble.", "wobble", VERSION_HINT, 0.3, 0.0, 1.0),
+                new osci::EffectParameter("Wobble Phase", "Controls the phase of the wobble.", "wobblePhase", VERSION_HINT, 0.0, -1.0, 1.0, 0.0001f, osci::LfoType::Sawtooth, 1.0f),
+            });
+        wobble->setName("Wobble");
+		return configureBuiltEffect(wobble);
+	}
+};

--- a/geometry/osci_PerspectiveProjector.cpp
+++ b/geometry/osci_PerspectiveProjector.cpp
@@ -1,0 +1,34 @@
+#include "osci_PerspectiveProjector.h"
+
+namespace osci {
+
+void PerspectiveProjector::setFieldOfViewRadians(float newFieldOfViewRadians) {
+    tangentHalfFov = std::tan(newFieldOfViewRadians * 0.5f);
+    focalLength = 1.0f / tangentHalfFov;
+}
+
+void PerspectiveProjector::setCameraPosition(Vec3 newCameraPosition) {
+    cameraPosition = newCameraPosition;
+}
+
+Vec3 PerspectiveProjector::toCameraSpace(Vec3 worldPoint) const {
+    return Vec3(worldPoint.x - cameraPosition.x, worldPoint.y - cameraPosition.y, worldPoint.z - cameraPosition.z);
+}
+
+Vec3 PerspectiveProjector::clampToViewVolume(Vec3 cameraPoint) const {
+    const auto z = std::clamp(cameraPoint.z, nearPlane, farPlane);
+    const auto verticalLimit = std::abs(z * tangentHalfFov);
+    const auto horizontalLimit = verticalLimit;
+
+    return Vec3(
+        std::clamp(cameraPoint.x, -horizontalLimit, horizontalLimit),
+        std::clamp(cameraPoint.y, -verticalLimit, verticalLimit),
+        z);
+}
+
+Vec3 PerspectiveProjector::project(Vec3 worldPoint) const {
+    const auto cameraPoint = clampToViewVolume(toCameraSpace(worldPoint));
+    return Vec3(cameraPoint.x * focalLength / cameraPoint.z, cameraPoint.y * focalLength / cameraPoint.z, 0.0f);
+}
+
+} // namespace osci

--- a/geometry/osci_PerspectiveProjector.h
+++ b/geometry/osci_PerspectiveProjector.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+
+namespace osci {
+
+struct Vec3 {
+    Vec3() = default;
+    Vec3(float xIn, float yIn, float zIn) : x(xIn), y(yIn), z(zIn) {}
+
+    float x = 0.0f;
+    float y = 0.0f;
+    float z = 0.0f;
+};
+
+class PerspectiveProjector {
+public:
+    void setFieldOfViewRadians(float newFieldOfViewRadians);
+    void setCameraPosition(Vec3 newCameraPosition);
+    Vec3 project(Vec3 worldPoint) const;
+
+private:
+    static constexpr float nearPlane = 0.001f;
+    static constexpr float farPlane = 100.0f;
+
+    Vec3 toCameraSpace(Vec3 worldPoint) const;
+    Vec3 clampToViewVolume(Vec3 cameraPoint) const;
+
+    Vec3 cameraPosition;
+    float tangentHalfFov = std::tan(0.5f);
+    float focalLength = 1.0f / tangentHalfFov;
+};
+
+} // namespace osci

--- a/osci_render_core.cpp
+++ b/osci_render_core.cpp
@@ -15,6 +15,9 @@
 #include "shape/osci_CubicBezierCurve.cpp"
 #include "shape/osci_QuadraticBezierCurve.cpp"
 
+// Include geometry implementations
+#include "geometry/osci_PerspectiveProjector.cpp"
+
 // Include midi implementations
 #include "midi/osci_MidiCCManager.cpp"
 

--- a/osci_render_core.h
+++ b/osci_render_core.h
@@ -55,6 +55,9 @@
 #include "shape/osci_QuadraticBezierCurve.h"
 #include "shape/osci_Shape.h"
 
+// Include geometry headers
+#include "geometry/osci_PerspectiveProjector.h"
+
 // Include midi headers
 #include "midi/osci_MidiCCManager.h"
 
@@ -72,19 +75,32 @@
 #include "dsp/osci_IntegerRatioSampleRateAdapter.h"
 
 // Include visualiser support headers
+#include "effects/osci_BitCrushEffect.h"
+#include "effects/osci_BulgeEffect.h"
 #include "effects/osci_BounceEffect.h"
+#include "effects/osci_DashedLineEffect.h"
 #include "effects/osci_DelayEffect.h"
 #include "effects/osci_DistortEffect.h"
+#include "effects/osci_DuplicatorEffect.h"
+#include "effects/osci_GodRayEffect.h"
+#include "effects/osci_KaleidoscopeEffect.h"
+#include "effects/osci_MultiplexEffect.h"
+#include "effects/osci_PerspectiveEffect.h"
+#include "effects/osci_PolygonizerEffect.h"
 #include "effects/osci_RippleEffect.h"
 #include "effects/osci_RotateEffect.h"
 #include "effects/osci_ScaleEffect.h"
 #include "effects/osci_SkewEffect.h"
 #include "effects/osci_SmoothEffect.h"
+#include "effects/osci_SpiralBitCrushEffect.h"
 #include "effects/osci_StereoEffect.h"
 #include "effects/osci_SwirlEffect.h"
 #include "effects/osci_TranslateEffect.h"
+#include "effects/osci_TwistEffect.h"
 #include "effects/osci_UnfoldEffect.h"
 #include "effects/osci_VectorCancellingEffect.h"
+#include "effects/osci_VortexEffect.h"
+#include "effects/osci_WobbleEffect.h"
 
 namespace osci {
 } // namespace osci


### PR DESCRIPTION
## Summary

Extracts the remaining rights-cleared effect implementations into `osci_render_core` and adds a small module-owned perspective projection helper so the moved `PerspectiveEffect` no longer depends on root app OBJ/camera files.

## Changes

- adds cleared effect headers under `effects/`
- adds `geometry/osci_PerspectiveProjector.*`
- exports the moved effects and geometry helper from the module header/source
- avoids app-owned `BinaryData` icon coupling in the moved effects
- keeps the moodycamel atomicops include self-contained when ChowDSP is not present

## Validation

- `git diff --check`
- no `BinaryData::` references in moved core effects
- consumed by the root extraction branch, which previously built macOS `osci-render`, macOS `sosci`, and Windows `osci-render`
